### PR TITLE
Updated Clubs and more page of RR Campus

### DIFF
--- a/content/docs/fourth_page.md
+++ b/content/docs/fourth_page.md
@@ -9,6 +9,7 @@ next: docs/fifth-page
 ### General 
 * [Official Website of PESU](https://pes.edu/)
 * [PESU Academy](https://www.pesuacademy.com/)
+* [Clubs](https://clubs.pes.edu/)
 
 ### Social
 * [Official PES University Discord server](https://discord.gg/pesu-discord-742797665301168220)

--- a/content/docs/rr-campus/clubs.md
+++ b/content/docs/rr-campus/clubs.md
@@ -15,24 +15,24 @@ next: docs/rr-campus/smpna
 | [The Alcoding Club](https://thealcodingclub.vercel.app) | 
 | [\|Q⟩Forest - Quantum Computing Community](https://www.instagram.com/pes.qforest/) |
 | WEAL - Mental Health in Tech Club |
-| [Google Developer Student Club(GDSC)](https://gdsc.community.dev/pes-university-bengaluru-india/) |
+| Google Developer Student Club(GDSC) |
 | [PES Innovation Lab](https://www.theinnovationlab.in/) |
 | [Aelous](https://aeolus.pes.edu) |
 | Equinox - The Space Club | 
 | [Apple Developers' Group (ADG)](https://adgpesu.wordpress.com) | 
 | ACM-W, PESU RR (Women in Tech Club) |
-| [Shunya -  The Official Math Club](https://shunyapes.vercel.app) | 
-| MahilAI - PESU RR (Tech for Women Club) |
+| [Shunya -  The Official Math Club](https://shunya-pes.vercel.app) | 
+| SahayAI - PESU RR |
 | Nexus |
 | AURA Club |
 | Encode.AI |
-| GronIT - Green technology club of RR Campus |
+| [GronIT - Green technology club of RR Campus](https://gronit-pes.vercel.app/) |
 | Arch Club |
 
 ## Racing Clubs 
 | Club Name |
 | --------- |
-| Team Haya (Raching Club under Mechanical Department |
+| Team Haya (Raching Club under Mechanical Department) |
 | Vega Racing Electric |
 
 ## Language and Book Clubs
@@ -67,7 +67,7 @@ next: docs/rr-campus/smpna
 | Club Name | Type |
 | --------- | ---- |
 | [PES MUN Society](https://pesmunsociety.wixsite.com/home) | Debate and Model United Nations |
-| TEDxPESU | TED Talks |
+| [TEDxPESU](https://ted-x-pesu-2025.vercel.app/) | TED Talks |
 | The PES Debating Society | Debate |
 
 ## Corporate Social Responsibility, Community Services and more
@@ -89,7 +89,7 @@ next: docs/rr-campus/smpna
 ## Gaming and more
 | Club Name |
 | --------- |
-| GCube PESU |
+| [GCube PESU](https://gcube-pes.vercel.app/) |
 
 
 ## Entrepreneurship and Trading
@@ -114,10 +114,21 @@ next: docs/rr-campus/smpna
 ## Department Clubs (Also called Verticals)
 
 ### Department of Computer Science and Engineering (RR Campus)
-To be added
+| Club Name |
+| -------- |
+| WEAL - Mental Health in Tech Club |
+| ACM-W, PESU RR (Women in Tech Club) |
+| Nexus |
+| [GronIT - Green technology club of RR Campus](https://gronit-pes.vercel.app/) |
+| [GCube PESU](https://gcube-pes.vercel.app/) |
+
 
 ### Department of Computer Science and Engineering (AIML) (RR Campus)
-To be added
+| Club Name |
+| -------- |
+| AURA Club |
+| Encode.AI |
+| Arch Club |
 
 ### Department of Electronics and Communication engineering (RR Campus)
 | Name | Remarks |
@@ -140,3 +151,4 @@ To be added
 | Crucible of Research and Innovation (CORI) | Satellite Communication |
 | Center for Data Science and Applied Machine Learning - Center for Cloud Computing and Big Data (CDSAML - CCBD) | Multidiscplinary |
 | Center for Robotics, Automation and Intelligent Systems | Robotics and more | 
+| Centre for Healthcare Engineering and Learning (cHEAL) | Healthcare | 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/imfing/hextra-starter-template
 
 go 1.21
 
-require github.com/imfing/hextra v0.9.7 // indirect
+require github.com/imfing/hextra v0.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/imfing/hextra v0.7.3 h1:dVGA1NTcWe+FaUMdrawEypPfrrmulq5NoK0we3nC330=
 github.com/imfing/hextra v0.7.3/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
 github.com/imfing/hextra v0.9.7 h1:Zg5n24us36Bn/S/5mEUPkRW6uwE6vHHEqWSgN0bPXaM=
 github.com/imfing/hextra v0.9.7/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.12.2 h1:qa+cHQ1LC/7ys9EhRNnHrRBAHu83Tm8rhh1oWO2a7cc=
+github.com/imfing/hextra v0.12.2/go.mod h1:vi+yhpq8YPp/aghvJlNKVnJKcPJ/VyAEcfC1BSV9ARo=


### PR DESCRIPTION
1. Removed the link from Google Developer Student Club (GDSC), leaving just plain text.
2. Updated Shunya - The Official Math Club 's website URL.
3. Renamed “MahilAI” to “SahayAI - PESU RR”.
4. Added a link to GronIT - Green technology club of RR Campus
5. Fixed a missing closing parenthesis in “Team Haya”.
6. Added links for TEDxPESU and GCube PESU.
7. Replaced “To be added” sections with lists of clubs for the CSE (RR) and CSE (AIML) departments.
8. Added a new row for “Centre for Healthcare Engineering and Learning (cHEAL)” at the end.
9. Added the official Clubs page links in Important Links page